### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/dataherald/model/chat_model.py
+++ b/dataherald/model/chat_model.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any
 
-from langchain.chat_models import ChatAnthropic, ChatGooglePalm, ChatOpenAI
+from langchain.chat_models import ChatAnthropic, ChatGooglePalm, ChatOpenAI, ChatLiteLLM
 from overrides import override
 
 from dataherald.model import LLMModel
@@ -18,11 +18,11 @@ class ChatModel(LLMModel):
     @override
     def get_model(self, **kwargs: Any) -> Any:
         if self.openai_api_key:
-            self.model = ChatOpenAI(model_name=self.model_name, **kwargs)
+            self.model = ChatLiteLLM(model_name=self.model_name, **kwargs)
         elif self.anthropic_api_key:
-            self.model = ChatAnthropic(model=self.model, **kwargs)
+            self.model = ChatLiteLLM(model=self.model, **kwargs)
         elif self.google_api_key:
-            self.model = ChatGooglePalm(model_name=self.model_name, **kwargs)
+            self.model = ChatLiteLLM(model_name=self.model_name, **kwargs)
         else:
             raise ValueError("No valid API key environment variable found")
         return self.model

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ sphinx==6.2.1
 sphinx-book-theme==1.0.1
 boto3==1.28.38
 botocore==1.31.38
+litellm >= 0.1.574


### PR DESCRIPTION
This PR adds support for 100+ models with a standard I/O interface using: https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the `ChatOpenAI` I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```