### PR TITLE
updated chromadb python package to latest (0.4.12) to mitigate error …

### DIFF
--- a/dataherald/vector_store/chroma.py
+++ b/dataherald/vector_store/chroma.py
@@ -1,7 +1,6 @@
 from typing import Any, List
 
 import chromadb
-from chromadb.config import Settings
 from overrides import override
 
 from dataherald.config import System
@@ -12,13 +11,10 @@ class Chroma(VectorStore):
     def __init__(
         self,
         system: System,
-        chroma_db_impl: str = "duckdb+parquet",
         persist_directory: str = "/app/chroma",
     ):
         super().__init__(system)
-        self.chroma_client = chromadb.Client(
-            Settings(chroma_db_impl=chroma_db_impl, persist_directory=persist_directory)
-        )
+        self.chroma_client = chromadb.PersistentClient(path=persist_directory)
 
     @override
     def query(

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ snowflake-sqlalchemy==1.4.7
 databricks-sql-connector==2.7.0
 sqlalchemy-databricks==0.2.0
 sqlalchemy-bigquery==1.6.1
-chromadb==0.3.26
+chromadb==0.4.12
 pytest-dotenv==0.5.2
 pinecone-client==2.2.2
 cryptography==40.0.2


### PR DESCRIPTION
Fix addressing this issue

https://github.com/Dataherald/dataherald/issues/174

Upgraded to latest python chromadb package and followed guidelines from official chromadb docs: https://docs.trychroma.com/migration

After update, golden-records can be uploaded to the system without error.

The rest of the operations seems to be working fine as well including /api/v1/question
