### PR TITLE
DH-4843 Add script to populate golden records

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,21 @@ curl -X 'POST' \
     }'
 ```
 
+### Run scripts
+Within the `scripts` folder located inside the `dataherald` directory, you have the ability to upgrade your versions. 
+For instance, if you are currently using version 0.0.3 and wish to switch to version 0.0.4, simply execute the following command:
+
+```
+docker-compose exec app python3 -m dataherald.scripts.migrate_v003_to_v004
+```
+Additionally, we provide a script for managing the Vector Store data. You can delete the existing data and upload all 
+the Golden Records to the 'golden_records' collection in MongoDB. If you are utilizing `Chroma` in-memory storage, it's 
+important to note that data is lost upon container restart. To repopulate the data, execute the following command:
+
+```
+docker-compose exec app python3 -m dataherald.scripts.delete_and_populate_golden_records
+```
+
 
 ## Replacing core modules
 The Dataherald engine is made up of replaceable modules. Each of these can be replaced with a different implementation that extends the base class. Some of the main modules are:

--- a/dataherald/scripts/delete_and_populate_golden_records.py
+++ b/dataherald/scripts/delete_and_populate_golden_records.py
@@ -1,0 +1,40 @@
+import os
+
+from sql_metadata import Parser
+
+import dataherald.config
+from dataherald.config import System
+from dataherald.db import DB
+from dataherald.vector_store import VectorStore
+
+if __name__ == "__main__":
+    settings = dataherald.config.Settings()
+    system = System(settings)
+    system.start()
+    storage = system.instance(DB)
+    golden_record_collection = os.environ.get(
+        "GOLDEN_RECORD_COLLECTION", "dataherald-staging"
+    )
+
+    vector_store = system.instance(VectorStore)
+    try:
+        vector_store.delete_collection(golden_record_collection)
+    except Exception:  # noqa: S110
+        pass
+    golden_records = storage.find_all("golden_records")
+    for golden_record in golden_records:
+        tables = Parser(golden_record["sql_query"]).tables
+        if len(tables) == 0:
+            tables = [""]
+        question = golden_record["question"]
+        vector_store.add_record(
+            documents=question,
+            collection=golden_record_collection,
+            metadata=[
+                {
+                    "tables_used": tables[0],
+                    "db_connection_id": golden_record["db_connection_id"],
+                }
+            ],
+            ids=[str(golden_record["_id"])],
+        )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ These documents will cover how to get started, how to set up an API from your da
    :caption: Tutorials
    :hidden:
 
+   tutorial.run_scripts
    tutorial.sample_database
    tutorial.finetune_sql_generator
    tutorial.chatgpt_plugin

--- a/docs/tutorial.run_scripts.rst
+++ b/docs/tutorial.run_scripts.rst
@@ -1,0 +1,17 @@
+Run scripts
+==================================
+
+Within the `scripts` folder located inside the `dataherald` directory, you have the ability to upgrade your versions. For instance, if you are currently using version 0.0.3 and wish to switch to version 0.0.4, simply execute the following command:
+
+.. code-block:: rst
+
+    docker-compose exec app python3 -m dataherald.scripts.migrate_v003_to_v004
+
+Script to populate golden records
+------------------------------
+
+Additionally, we provide a script for managing the Vector Store data. You can delete the existing data and upload all the Golden Records to the `golden_records` collection in MongoDB. If you are utilizing `Chroma` in-memory storage, it's important to note that data is lost upon container restart. To repopulate the data, execute the following command:
+
+.. code-block:: rst
+
+    docker-compose exec app python3 -m dataherald.scripts.delete_and_populate_golden_records


### PR DESCRIPTION
Run this command to populate the vector store using the golden records collection
`docker-compose exec app python3 -m dataherald.scripts.delete_and_populate_golden_records`