### PR TITLE
Add get_response_local_file endpoint to API and not use AWS S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,4 @@ MONGODB_DB_PASSWORD = 'admin'
 # The enncryption key is used to encrypt database connection info before storing in Mongo. Please refer to the README on how to set it.
 S3_AWS_ACCESS_KEY_ID=
 S3_AWS_SECRET_ACCESS_KEY=
+ONLY_STORE_CSV_FILES_LOCALLY = TRUE # Set to TRUE if you only want to store files locally instead of S3

--- a/dataherald/api/__init__.py
+++ b/dataherald/api/__init__.py
@@ -137,6 +137,13 @@ class API(Component, ABC):
         pass
 
     @abstractmethod
+    def get_response_local_file(
+        self, response_id: str, background_tasks: BackgroundTasks
+    ) -> FileResponse:
+        pass
+
+
+    @abstractmethod
     def delete_golden_record(self, golden_record_id: str) -> dict:
         pass
 

--- a/dataherald/api/fastapi.py
+++ b/dataherald/api/fastapi.py
@@ -408,6 +408,34 @@ class FastAPI(API):
             file_location,
             media_type="text/csv",
         )
+        
+    @override
+    def get_response_local_file(
+        self, response_id: str, background_tasks: BackgroundTasks
+    ) -> FileResponse:
+        response_repository = ResponseRepository(self.storage)
+        question_repository = QuestionRepository(self.storage)
+        db_connection_repository = DatabaseConnectionRepository(self.storage)
+        try:
+            result = response_repository.find_by_id(response_id)
+            question = question_repository.find_by_id(result.question_id)
+            db_connection = db_connection_repository.find_by_id(
+                question.db_connection_id
+            )
+        except InvalidId as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+        if not result:
+            raise HTTPException(
+                status_code=404, detail="Question, response, or db_connection not found"
+            )
+
+        file_location = result.csv_file_path
+
+        return FileResponse(
+            file_location,
+            media_type="text/csv",
+        )
 
     @override
     def update_response(self, response_id: str) -> Response:

--- a/dataherald/config.py
+++ b/dataherald/config.py
@@ -50,6 +50,7 @@ class Settings(BaseSettings):
     encrypt_key: str = os.environ.get("ENCRYPT_KEY")
     s3_aws_access_key_id: str | None = os.environ.get("S3_AWS_ACCESS_KEY_ID")
     s3_aws_secret_access_key: str | None = os.environ.get("S3_AWS_SECRET_ACCESS_KEY")
+    only_store_csv_files_locally: str | None = os.environ.get("ONLY_STORE_CSV_FILES_LOCALLY")
 
     def require(self, key: str) -> Any:
         val = self[key]

--- a/dataherald/server/fastapi/__init__.py
+++ b/dataherald/server/fastapi/__init__.py
@@ -170,6 +170,13 @@ class FastAPI(dataherald.server.Server):
             methods=["GET"],
             tags=["Responses"],
         )
+        
+        self.router.add_api_route(
+            "/api/v1/responses/{response_id}/localfile",
+            self.get_response_local_file,
+            methods=["GET"],
+            tags=["Responses"],
+        )
 
         self.router.add_api_route(
             "/api/v1/responses/{response_id}",
@@ -312,6 +319,12 @@ class FastAPI(dataherald.server.Server):
     ) -> FileResponse:
         """Get a response file"""
         return self._api.get_response_file(response_id, background_tasks)
+
+    def get_response_file_file(
+        self, response_id: str, background_tasks: BackgroundTasks
+    ) -> FileResponse:
+        """Get a response file from local file system (within docker container)"""
+        return self._api.get_response_local_file(response_id, background_tasks)
 
     def execute_sql_query(self, query: Query) -> tuple[str, dict]:
         """Executes a query on the given db_connection_id"""

--- a/dataherald/sql_generator/create_sql_query_status.py
+++ b/dataherald/sql_generator/create_sql_query_status.py
@@ -10,6 +10,9 @@ from dataherald.sql_database.models.types import DatabaseConnection
 from dataherald.types import Response, SQLQueryResult
 from dataherald.utils.s3 import S3
 
+from dataherald.config import Settings
+
+
 
 def format_error_message(response: Response, error_message: str) -> Response:
     # Remove the complete query
@@ -40,10 +43,13 @@ def create_csv_file(
             writer.writerow(rows[0].keys())
             for row in rows:
                 writer.writerow(row.values())
-        s3 = S3()
-        response.csv_file_path = s3.upload(
-            file_location, database_connection.file_storage
-        )
+        if Settings().only_store_csv_files_locally:
+          response.csv_file_path = file_location
+        else: 
+          s3 = S3()
+          response.csv_file_path = s3.upload(
+              file_location, database_connection.file_storage
+          )
     response.sql_query_result = SQLQueryResult(columns=columns, rows=rows)
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,6 +55,7 @@ The related endpoints are:
 * :doc:`list_responses <api.list_responses>` -- ``GET api/v1/responses``
 * :doc:`get_response <api.get_response>` -- ``GET api/v1/responses/{response_id}``
 * :doc:`get_response_file <api.get_response_file>` -- ``GET api/v1/responses/{response_id}/file``
+* :doc:`get_response_file <api.get_response_local_file>` -- ``GET api/v1/responses/{response_id}/localfile``
 
 **Response resource example:**
 
@@ -158,3 +159,4 @@ Related endpoints are:
     api.list_responses
     api.get_response
     api.get_response_file
+    api.get_response_local_file


### PR DESCRIPTION
I like the new feature to save as CSV but this only works with an Amazon S3 account.
Considering the file already gets saved to the server it'd be convenient if that file could be retrieved as a FileResponse directly without storing the intermediate result on the cloud. We for one are not interested in storing the created CSV files.

This feature adds a config `ONLY_STORE_CSV_FILES_LOCALLY` to set whether the user is fine only saving to S3.

Basically I would like it to work even if no S3_AWS credentials set up. This config is a quick means to check whether that can be bypassed.

Then the result can be retrieved using the a new api call `get_response_local_file` which just creates a FileResponse from the local file.