### PR TITLE
README minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ You should set in the endpoint param `path_to_credentials_file` the path, for ex
 ```
 
 ```
-"connection_uri": bigquery://<project>/<database>
+"connection_uri": bigquery://<project_id>/<dataset>
 ```
 
 
@@ -285,7 +285,7 @@ Once a database was scanned you can use this endpoint to retrieve the tables nam
 
 ```
 curl -X 'GET' \
-  '<host>/api/v1/table-descriptions?db_connection_id=64dfa0e103f5134086f7090c&table_name=foo' \
+  '<host>/api/v1/table-descriptions?db_connection_id=<use_your_db_connection_id>&table_name=foo' \
   -H 'accept: application/json'
 ```
 
@@ -312,7 +312,7 @@ All request body fields are optional, and only the fields that are explicitly se
 
 ```
 curl -X 'PATCH' \
-  '<host>/api/v1/table-descriptions/64dfa0e103f5134086f7090c' \
+  '<host>/api/v1/table-descriptions/<use_your_db_connection_id>' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,5 @@ tiktoken==0.5.1
 duckdb-engine==0.9.1
 duckdb==0.9.1
 PyMySQL==1.1.0
+langsmith==0.0.69
+


### PR DESCRIPTION
     - In BigQuery, Project ID should be used (Project name and Project ID might be different, in that case Project ID Should be used
     - In BigQuery, the Right terminology is Datasets equivalent to Database in other DBs.
     - Replaced the example which had a random DB connection ID with the text '<use_your_db_connection_id>'