### PR TITLE
fixing typo in function name

### DIFF
--- a/dataherald/sql_generator/dataherald_finetuning_agent.py
+++ b/dataherald/sql_generator/dataherald_finetuning_agent.py
@@ -182,7 +182,7 @@ class TablesSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
     def cosine_similarity(self, a: List[float], b: List[float]) -> float:
         return round(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)), 4)
 
-    def similart_tables_based_on_few_shot_examples(self, df: pd.DataFrame) -> List[str]:
+    def similar_tables_based_on_few_shot_examples(self, df: pd.DataFrame) -> List[str]:
         most_similar_tables = set()
         if self.few_shot_examples is not None:
             for example in self.few_shot_examples:
@@ -224,7 +224,7 @@ class TablesSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         )
         df = df.sort_values(by="similarities", ascending=True)
         df = df.tail(TOP_TABLES)
-        most_similar_tables = self.similart_tables_based_on_few_shot_examples(df)
+        most_similar_tables = self.similar_tables_based_on_few_shot_examples(df)
         table_relevance = ""
         for _, row in df.iterrows():
             table_relevance += f'Table: `{row["table_name"]}`, relevance score: {row["similarities"]}\n'

--- a/dataherald/sql_generator/dataherald_sqlagent.py
+++ b/dataherald/sql_generator/dataherald_sqlagent.py
@@ -246,7 +246,7 @@ class TablesSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
     def cosine_similarity(self, a: List[float], b: List[float]) -> float:
         return round(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)), 4)
 
-    def similart_tables_based_on_few_shot_examples(self, df: pd.DataFrame) -> List[str]:
+    def similar_tables_based_on_few_shot_examples(self, df: pd.DataFrame) -> List[str]:
         most_similar_tables = set()
         if self.few_shot_examples is not None:
             for example in self.few_shot_examples:
@@ -288,7 +288,7 @@ class TablesSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         )
         df = df.sort_values(by="similarities", ascending=True)
         df = df.tail(TOP_TABLES)
-        most_similar_tables = self.similart_tables_based_on_few_shot_examples(df)
+        most_similar_tables = self.similar_tables_based_on_few_shot_examples(df)
         table_relevance = ""
         for _, row in df.iterrows():
             table_relevance += f'Table: `{row["table_name"]}`, relevance score: {row["similarities"]}\n'


### PR DESCRIPTION
This PR fixes a very simple typo fixing in functions name:
`similart_tables_based_on_few_shot_examples(...)` -> `similar_tables_based_on_few_shot_examples(...)`