### PR TITLE
fix sorting table relevance scores

### DIFF
--- a/services/engine/dataherald/sql_generator/dataherald_sqlagent.py
+++ b/services/engine/dataherald/sql_generator/dataherald_sqlagent.py
@@ -294,8 +294,8 @@ class TablesSQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
         df["similarities"] = df.table_embedding.apply(
             lambda x: self.cosine_similarity(x, question_embedding)
         )
-        df = df.sort_values(by="similarities", ascending=True)
-        df = df.tail(TOP_TABLES)
+        df = df.sort_values(by="similarities", ascending=False)
+        df = df.head(TOP_TABLES)
         most_similar_tables = self.similar_tables_based_on_few_shot_examples(df)
         table_relevance = ""
         for _, row in df.iterrows():


### PR DESCRIPTION
This fixes sorting table relevance scores in the output.

Previously:
```
engine   | Action: DbTablesWithRelevanceScores
engine   | Action Input: what is the total number of albums
engine   | Observation: Table: `main.media_types`, relevance score: 0.0771
engine   | Table: `main.customers`, relevance score: 0.0827
engine   | Table: `main.employees`, relevance score: 0.1003
engine   | Table: `main.invoices`, relevance score: 0.1282
engine   | Table: `main.invoice_items`, relevance score: 0.1407
engine   | Table: `main.genres`, relevance score: 0.1568
```

Now:
```
engine   | Action: DbTablesWithRelevanceScores
engine   | Action Input: what is the total number of albums
engine   | Observation: Table: `main.albums`, relevance score: 0.3576
engine   | Table: `main.artists`, relevance score: 0.2226
engine   | Table: `main.playlist_track`, relevance score: 0.1908
engine   | Table: `main.playlists`, relevance score: 0.1676
engine   | Table: `main.genres`, relevance score: 0.1568
```